### PR TITLE
Adding a `div` compiler

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -612,6 +612,33 @@ function strong(node) {
 }
 
 /**
+ * Stringify a div element
+ *
+ * @example
+ *   div({
+ *     children: [
+ *       {
+ *         type: 'text',
+ *         value: 'foo'
+ *       }
+ *     ]
+ *   }); // '<div>foo</div>'
+ *
+ * @param {Node} node - Node to compile.
+ * @return {string} - Compiled node.
+ * @this {HTMLCompiler}
+ */
+function div(node) {
+    node.data = node.data || {}
+    node.data.htmlName = 'div'
+    return h(this, node, {
+        'name': 'div',
+        'type': 'div',
+        'content': this.all(node).join('')
+    }, node.data);
+}
+
+/**
  * Stringify emphasised content.
  *
  * @example
@@ -885,6 +912,7 @@ visitors.listItem = listItem;
 visitors.paragraph = paragraph;
 visitors.heading = heading;
 visitors.table = table;
+visitors.div = div;
 visitors.code = code;
 visitors.html = html;
 visitors.horizontalRule = rule;

--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -631,9 +631,9 @@ function strong(node) {
 function div(node) {
     node.data = node.data || {}
     node.data.htmlName = 'div'
+
     return h(this, node, {
         'name': 'div',
-        'type': 'div',
         'content': this.all(node).join('')
     }, node.data);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -251,6 +251,30 @@ describe('mdast-html()', function () {
         );
     });
 
+    it('should support div elements in modified AST nodes', function () {
+        var processor = mdast().use(function () {
+            return function (ast) {
+                var code = ast.children[0].children[0];
+
+                code.data = {
+                    'htmlContent': '<span class="token">' +
+                        code.value +
+                        '</span>'
+                };
+
+                ast.children[0] = {
+                  type: 'div',
+                  children: [code]
+                }
+            }
+        }).use(html);
+
+        assert.strictEqual(
+            processor.process('`var`'),
+            '<div><code><span class="token">var</span></code></div>\n'
+        );
+    });
+
     it('should overwrite content', function () {
         var processor = mdast().use(function () {
             return function (ast) {


### PR DESCRIPTION
When developing plugins which modify the ast, I wanted the ability to create simple wrapper divs.  

I just noticed the new functionality where you can specify a custom element name and I think this is a good improvement overall.  What wasn't clear to me was which element I should use as the base, if what I wanted was just a simple div which wrapped whatever children the node has.

Would be happy to clean up and simplify the implementation or hear about better approaches to solving this.
