### PR TITLE
Fix output of unknown node with multiple children

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -147,7 +147,7 @@ function generateFootnotes() {
  * @this {HTMLCompiler}
  */
 function unknown(node) {
-    var content = 'children' in node ? this.all(node) : node.value;
+    var content = 'children' in node ? this.all(node).join('') : node.value;
 
     return h(this, node, {
         'name': 'div',


### PR DESCRIPTION
HTML output for unknown nodes are separated by commas.  Converting the content value to a string.
