### PR TITLE
pass handlers option through to mdast-util-to-hast

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function plugin(processor, options) {
   var settings = options || {};
   var clean = settings.sanitize;
   var schema = clean && typeof clean === 'object' ? clean : null;
+  var handlers = settings.handlers || {};
 
   Compiler.prototype.compile = compile;
 
@@ -29,7 +30,7 @@ function plugin(processor, options) {
 
   function compile(node) {
     var root = node && node.type && node.type === 'root';
-    var hast = toHAST(node, {allowDangerousHTML: !clean});
+    var hast = toHAST(node, {allowDangerousHTML: !clean, handlers: handlers});
     var result;
 
     if (clean) {

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ var github = require('remark-github');
 var commonmark = require('commonmark.json');
 var toVFile = require('to-vfile');
 var hidden = require('is-hidden');
-var all = require('mdast-util-to-hast/lib/all')
+var all = require('mdast-util-to-hast/lib/all');
 var html = require('..');
 
 var read = fs.readFileSync;
@@ -178,7 +178,7 @@ test('remark-html()', function (t) {
       };
     })
     .use(html, {handlers: {
-      paragraph: function (h, node, parent) {
+      paragraph: function (h, node) {
         node.children[0].value = 'changed';
         return h(node, 'p', all(h, node));
       }

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ var github = require('remark-github');
 var commonmark = require('commonmark.json');
 var toVFile = require('to-vfile');
 var hidden = require('is-hidden');
+var all = require('mdast-util-to-hast/lib/all')
 var html = require('..');
 
 var read = fs.readFileSync;
@@ -166,6 +167,27 @@ test('remark-html()', function (t) {
     }),
     '<i class="charlie">delta</i>',
     'should stringify unknown nodes'
+  );
+
+  processor = remark()
+    .use(function () {
+      return function (ast) {
+        ast.children[0].children[0].data = {
+          hProperties: {title: 'overwrite'}
+        };
+      };
+    })
+    .use(html, {handlers: {
+      paragraph: function (h, node, parent) {
+        node.children[0].value = 'changed';
+        return h(node, 'p', all(h, node));
+      }
+    }});
+
+  t.equal(
+    processor.process('paragraph text').toString(),
+    '<p>changed</p>\n',
+    'should allow overriding handlers'
   );
 
   processor = remark()


### PR DESCRIPTION
This enables support for overriding handlers in mdast-util-to-hast as added in https://github.com/syntax-tree/mdast-util-to-hast/pull/10