### PR TITLE
Update capitalization of allowDangerousHtml

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function plugin(options) {
 
   function compiler(node, file) {
     var root = node && node.type && node.type === 'root'
-    var hast = toHast(node, {allowDangerousHTML: !clean, handlers: handlers})
+    var hast = toHast(node, {allowDangerousHtml: !clean, handlers: handlers})
     var result
 
     if (file.extname) {


### PR DESCRIPTION
Before this change `mdast-util-to-hast` would output a warning.

```
mdast-util-to-hast: deprecation: `allowDangerousHTML` is nonstandard, use `allowDangerousHtml` instead
```

https://github.com/syntax-tree/mdast-util-to-hast/blob/master/lib/index.js#L22-L28
